### PR TITLE
chore(eslintrc.json): ignore `package-lock.json` to secret rules plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,5 +16,13 @@
         }
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["package-lock.json"],
+      "rules": {
+        "no-secrets/no-secrets": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
fix #23 