### PR TITLE
chore(eslintrc.json): ignore `eslintrc.json` to secret rules plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
   },
   "overrides": [
     {
-      "files": ["package-lock.json"],
+      "files": ["package-lock.json", ".eslintrc.json"],
       "rules": {
         "no-secrets/no-secrets": "off"
       }


### PR DESCRIPTION
fix #26